### PR TITLE
add/tokenizing with entity type

### DIFF
--- a/code/inference.py
+++ b/code/inference.py
@@ -63,7 +63,7 @@ def load_test_dataset(dataset_dir, tokenizer):
     test_dataset = load_data(dataset_dir)
     test_label = list(map(int, test_dataset['label'].values))
     # tokenizing dataset
-    tokenized_test = tokenized_dataset(test_dataset, tokenizer)
+    tokenized_test = tokenized_dataset_with_wordtype(test_dataset, tokenizer)
     return test_dataset['id'], tokenized_test, test_label
 
 
@@ -78,7 +78,7 @@ def main(args):
 
     # load my model
     MODEL_NAME = args.model_dir  # model dir.
-    model = AutoModelForSequenceClassification.from_pretrained(args.model_dir)
+    model = AutoModelForSequenceClassification.from_pretrained(MODEL_NAME)
     model.parameters
     model.to(device)
 
@@ -100,7 +100,7 @@ def main(args):
         {'id': test_id, 'pred_label': pred_answer, 'probs': output_prob, })
 
     # 최종적으로 완성된 예측한 라벨 csv 파일 형태로 저
-    output.to_csv('./data/prediction/submission.csv', index=False)
+    output.to_csv('./data/prediction/0509080834_checkpoint-2500.csv', index=False)
     #### 필수!! ##############################################
     print('---- Finish! ----')
 
@@ -109,7 +109,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
 
     # model dir
-    parser.add_argument('--model_dir', type=str, default="./best_model")
+    parser.add_argument('--model_dir', type=str, default="./results/0509080834/checkpoint-2500")
     args = parser.parse_args()
     print(args)
     main(args)

--- a/code/train.py
+++ b/code/train.py
@@ -59,8 +59,8 @@ def train():
     dev_label = label_to_num(dev_dataset['label'].values)
 
     # tokenizing dataset
-    tokenized_train = tokenized_dataset(train_dataset, tokenizer)
-    tokenized_dev = tokenized_dataset(dev_dataset, tokenizer)
+    tokenized_train = tokenized_dataset_with_wordtype(train_dataset, tokenizer)
+    tokenized_dev = tokenized_dataset_with_wordtype(dev_dataset, tokenizer)
 
     # make dataset for pytorch.
     RE_train_dataset = RE_Dataset(tokenized_train, train_label)
@@ -77,6 +77,7 @@ def train():
         MODEL_NAME, config=model_config)
     print(model.config)
     model.parameters
+    model.resize_token_embeddings(len(tokenizer))
     model.to(device)
 
     # 사용한 option 외에도 다양한 option들이 있습니다.
@@ -85,12 +86,12 @@ def train():
         output_dir=f'./results/{run_name}',         # output directory
         save_total_limit=5,             # number of total save model.
         save_steps=1500,                # model saving step.
-        num_train_epochs=10,            # total number of training epochs
+        num_train_epochs=5,            # total number of training epochs
         learning_rate=5e-5,             # learning_rate
-        per_device_train_batch_size=16, # batch size per device during training
-        per_device_eval_batch_size=16,  # batch size for evaluation
+        per_device_train_batch_size=32, # batch size per device during training
+        per_device_eval_batch_size=32,  # batch size for evaluation
         warmup_steps=500,               # number of warmup steps for learning rate scheduler
-        weight_decay=0.01,              # strength of weight decay
+        weight_decay=0.01,              # strength of wfeight decay
         logging_dir=f'./results/{run_name}/logs',   # directory for storing logs
         logging_steps=100,              # log saving step.
         evaluation_strategy='steps',    # evaluation strategy to adopt during training

--- a/utils/preprocessing.py
+++ b/utils/preprocessing.py
@@ -6,8 +6,8 @@ def preprocessing_dataset(dataset):
     subject_entity = []
     object_entity = []
     for i, j in zip(dataset['subject_entity'], dataset['object_entity']):
-        i = i[1:-1].split(',')[0].split(':')[1].lstrip(" '").rstrip("'")
-        j = j[1:-1].split(',')[0].split(':')[1].lstrip(" '").rstrip("'")
+        i = i[1:-1].split(',')[0].split(':')[1]
+        j = j[1:-1].split(',')[0].split(':')[1]
 
         subject_entity.append(i)
         object_entity.append(j)
@@ -16,9 +16,39 @@ def preprocessing_dataset(dataset):
     return out_dataset
 
 
+def preprocessing_dataset_with_wordtype(dataset):
+    """ 처음 불러온 csv 파일을 원하는 형태의 DataFrame으로 변경 시켜줍니다."""
+    subject_entity = []
+    object_entity = []
+    dataset['subject_entity_type'] = dataset['subject_entity'].apply(lambda x: 'S' + dict(eval(x))['type'])
+    dataset['object_entity_type'] = dataset['object_entity'].apply(lambda x: 'O' + dict(eval(x))['type'])
+    dataset['subject_begin'] = dataset['subject_entity'].apply(lambda x: dict(eval(x))['start_idx'])
+    dataset['subject_end'] = dataset['subject_entity'].apply(lambda x: dict(eval(x))['end_idx'])
+    dataset['object_begin'] = dataset['object_entity'].apply(lambda x: dict(eval(x))['start_idx'])
+    dataset['object_end'] = dataset['object_entity'].apply(lambda x: dict(eval(x))['end_idx'])
+    
+    for i, j in zip(dataset['subject_entity'], dataset['object_entity']):
+        i = i[1:-1].split(',')[0].split(':')[1]
+        j = j[1:-1].split(',')[0].split(':')[1]
+
+        subject_entity.append(i)
+        object_entity.append(j)
+        
+    out_dataset = pd.DataFrame({'id': dataset['id'], 'sentence': dataset['sentence'],
+                               'subject_entity': subject_entity, 'object_entity': object_entity, 'label': dataset['label'], 
+                               'subject_entity_type': dataset['subject_entity_type'],
+                               'object_entity_type': dataset['object_entity_type'],
+                               'object_end': dataset['object_end'],
+                               'object_begin': dataset['object_begin'],
+                               'subject_end': dataset['subject_end'],
+                               'subject_begin': dataset['subject_begin'],})
+    return out_dataset
+
+
+
 def load_data(dataset_dir):
     """ csv 파일을 경로에 맡게 불러 옵니다. """
     pd_dataset = pd.read_csv(dataset_dir)
-    dataset = preprocessing_dataset(pd_dataset)
+    dataset = preprocessing_dataset_with_wordtype(pd_dataset)
 
     return dataset

--- a/utils/tokenizing.py
+++ b/utils/tokenizing.py
@@ -15,3 +15,48 @@ def tokenized_dataset(dataset, tokenizer):
         add_special_tokens=True,
     )
     return tokenized_sentences
+
+
+def tokenized_dataset_with_wordtype(df, tokenizer):
+    """ tokenizer에 따라 sentence를 tokenizing 합니다."""
+    sents = []
+    
+    for idx, row in df.iterrows():
+        sent = ''
+        s_st = row['subject_begin']
+        s_end = row['subject_end']
+        o_st = row['object_begin']
+        o_end = row['object_end']
+    
+        if s_st < o_st:
+            sent = row['sentence']
+            sent = sent[:s_st] + '[' +row['subject_entity_type'] + ']' + sent[s_st:]
+            sent = sent[:s_end+7] + '[/' +row['subject_entity_type'] + ']' + sent[s_end+7:]
+            sent = sent[:o_st+13] + '[' +row['object_entity_type'] + ']' + sent[o_st+13:]
+            sent = sent[:o_end+20] + '[/' +row['object_entity_type'] + ']' + sent[o_end+20:]
+        else :
+            sent = row['sentence']
+            sent = sent[:o_st] + '[' +row['object_entity_type'] + ']' + sent[o_st:]
+            sent = sent[:o_end+7] + '[/' +row['object_entity_type'] + ']' + sent[o_end+7:]
+            sent = sent[:s_st+13] + '[' +row['subject_entity_type'] + ']' + sent[s_st+13:]
+            sent = sent[:s_end+20] + '[/' +row['subject_entity_type'] + ']' + sent[s_end+20:]
+        
+        sents.append(sent)
+    
+    tokens = ['[SPER]','[/SPER]','[SORG]','[/SORG]',
+              '[OPER]','[/OPER]','[OORG]','[/OORG]',
+              '[ODAT]','[/ODAT]','[OLOC]','[/OLOC]',
+              '[OPOH]','[/OPOH]','[ONOH]','[/ONOH]']
+    
+    tokenizer.add_tokens(tokens,special_tokens=True)
+    
+    tokenized_sentences = tokenizer(
+        sents,
+        return_tensors="pt",
+        padding=True,
+        truncation=True,
+        max_length=256,
+        add_special_tokens=True,
+    )
+    
+    return tokenized_sentences


### PR DESCRIPTION
tokenizing 방법 적용

1. 기존 토크나이징
- <cls> word1 <sep> word2 <sep> sentence <sep>
    - 문제 1. <sep> 토큰이 3번 들어감, 기존 bert는 <sep> 2개 나왔을 때 항상 입력 sequence가 끝난다고 생각하고 있음
    - 문제 2.  word1과 word2가 sentence에서 한번 더 등장함. sequence가 괜히 더 길어짐
    - 문제 3. word type 정보가 없음

1. 개선된 토크나이징 ( subject word1 = 이순신 , object word2 = 지휘관)
- <cls> <entity><PER>이순신</PER></entity>은 조선 중기의 무신이자 임진왜란 당시 조선 수군을 통솔했던 <entity><POH>지휘관</POH></entity>이자 구국영웅으로, 자는 여해이며, 시호는 충무공이다. <sep>
    - 문제 1,2,3을 해결했지만 이 task에선 subject와 object가 확실히 구별됨. 예를 들어, subject가 PER 타입일 경우 정답 레이블은 per:altemate names과 같은 per: 에서만 나오는 것을 볼 수 있음
    - 이 task의 label은 sub : sub, obj 둘의 관계
    - 여기에서 개선점을 찾아볼 수 있음
        - 문제점 1. </per></entity> 라는 식으로 단어의 끝을 2번 표현함
        - 문제점 2. sub가 PER일 때와 obj가 PER일 때 답의 분포가 확연히 달라지는데 그게 반영되지 않음.
            - cf) sub가 PER일 땐 per: 에서 답이 결정되는 반면 obj가 PER 일 땐 답이 무조건 per에서 나오진 않음, 예를들어 org : employee가 나올 수도 있음. (그렇지만 per : birth 와 같은 것이 나올 순 없음 따라서 활용 가능)

1. 현재 적용한 토크나이징 ( subject word1 = 이순신 , object word2 = 지휘관)
- <cls> <SPER>이순신</SPER>은 조선 중기의 무신이자 임진왜란 당시 조선 수군을 통솔했던 <OPOH>지휘관</OPOH>이자 구국영웅으로, 자는 여해이며, 시호는 충무공이다. <sep>
    - 효과 1. 위에서의 문제점 1을 해결하여 중복된 단어의 끝을 포함하는 토큰을 하나만 사용함
    - 효과 2. <SPER>과 <OPER>의 의미를 구별